### PR TITLE
feat: Add support for numeric literals (float, hex, binary)

### DIFF
--- a/include/msl_parser/lexer.h
+++ b/include/msl_parser/lexer.h
@@ -19,6 +19,17 @@ private:
     size_t current = 0;
     uint32_t line = 1;
     uint32_t column = 1;
+    
+    void scanToken();
+    void number();
+    
+    bool isDigit(char c);
+    bool isHexDigit(char c);
+    bool isAtEnd();
+    char advance();
+    char peek();
+    char peekNext();
+    void addToken(TokenType type);
 };
 
 } // namespace msl_parser

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -1,31 +1,137 @@
 #include "msl_parser/lexer.h"
+#include <cctype>
 
 namespace msl_parser {
 
 Lexer::Lexer(const std::string& source) : source(source) {}
 
 std::vector<Token> Lexer::scanTokens() {
-    while (current < source.length()) {
+    while (!isAtEnd()) {
         start = current;
-        
-        char c = source[current];
-        if (c >= '0' && c <= '9') {
-            // Simple integer literal scanning
-            while (current < source.length() && source[current] >= '0' && source[current] <= '9') {
-                current++;
-            }
-            std::string lexeme = source.substr(start, current - start);
-            tokens.push_back(Token(TokenType::INTEGER_LITERAL, lexeme, line, column));
-            column += current - start;
-        } else {
-            // Skip unknown characters for now
-            current++;
-            column++;
-        }
+        scanToken();
     }
     
     tokens.push_back(Token(TokenType::END_OF_FILE, "", line, column));
     return tokens;
+}
+
+void Lexer::scanToken() {
+    char c = advance();
+    
+    if (isDigit(c)) {
+        number();
+    } else if (c == ' ' || c == '\r' || c == '\t') {
+        // Ignore whitespace
+    } else if (c == '\n') {
+        line++;
+        column = 1;
+    } else {
+        // Skip unknown characters for now
+    }
+}
+
+void Lexer::number() {
+    // Check for hex or binary prefix
+    if (peek() == 'x' || peek() == 'X') {
+        // Hexadecimal
+        advance(); // consume 'x' or 'X'
+        while (isHexDigit(peek())) {
+            advance();
+        }
+        addToken(TokenType::INTEGER_LITERAL);
+        return;
+    } else if (peek() == 'b' || peek() == 'B') {
+        // Binary
+        advance(); // consume 'b' or 'B'
+        while (peek() == '0' || peek() == '1') {
+            advance();
+        }
+        addToken(TokenType::INTEGER_LITERAL);
+        return;
+    }
+    
+    // Decimal integer part
+    while (isDigit(peek())) {
+        advance();
+    }
+    
+    // Look for a fractional part
+    if (peek() == '.') {
+        // Check if there's a digit after the dot or if it's just a trailing dot
+        if (isDigit(peekNext())) {
+            // Consume the "."
+            advance();
+            
+            while (isDigit(peek())) {
+                advance();
+            }
+        } else {
+            // Just a trailing dot like "10."
+            advance();
+        }
+    }
+    
+    // Look for exponent
+    if (peek() == 'e' || peek() == 'E') {
+        advance();
+        if (peek() == '+' || peek() == '-') {
+            advance();
+        }
+        while (isDigit(peek())) {
+            advance();
+        }
+    }
+    
+    // Check for float suffix
+    if (peek() == 'f' || peek() == 'F' || peek() == 'h' || peek() == 'H') {
+        advance();
+        addToken(TokenType::FLOAT_LITERAL);
+        return;
+    }
+    
+    // Determine if it's float or integer
+    std::string text = source.substr(start, current - start);
+    if (text.find('.') != std::string::npos || 
+        text.find('e') != std::string::npos || 
+        text.find('E') != std::string::npos) {
+        addToken(TokenType::FLOAT_LITERAL);
+    } else {
+        addToken(TokenType::INTEGER_LITERAL);
+    }
+}
+
+bool Lexer::isDigit(char c) {
+    return c >= '0' && c <= '9';
+}
+
+bool Lexer::isHexDigit(char c) {
+    return (c >= '0' && c <= '9') || 
+           (c >= 'a' && c <= 'f') || 
+           (c >= 'A' && c <= 'F');
+}
+
+bool Lexer::isAtEnd() {
+    return current >= source.length();
+}
+
+char Lexer::advance() {
+    column++;
+    return source[current++];
+}
+
+char Lexer::peek() {
+    if (isAtEnd()) return '\0';
+    return source[current];
+}
+
+char Lexer::peekNext() {
+    if (current + 1 >= source.length()) return '\0';
+    return source[current + 1];
+}
+
+void Lexer::addToken(TokenType type) {
+    std::string text = source.substr(start, current - start);
+    tokens.push_back(Token(type, text, line, column - text.length()));
 }
 
 } // namespace msl_parser

--- a/tests/test_lexer.cpp
+++ b/tests/test_lexer.cpp
@@ -12,3 +12,154 @@ TEST(LexerTest, ScanSingleInteger) {
     EXPECT_EQ(tokens[0].lexeme, "42");
     EXPECT_EQ(tokens[1].type, TokenType::END_OF_FILE);
 }
+
+TEST(LexerTest, ScanFloatLiterals) {
+    // Simple float
+    {
+        Lexer lexer("3.14");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 2);
+        EXPECT_EQ(tokens[0].type, TokenType::FLOAT_LITERAL);
+        EXPECT_EQ(tokens[0].lexeme, "3.14");
+    }
+    
+    // Float with f suffix
+    {
+        Lexer lexer("1.0f");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 2);
+        EXPECT_EQ(tokens[0].type, TokenType::FLOAT_LITERAL);
+        EXPECT_EQ(tokens[0].lexeme, "1.0f");
+    }
+    
+    // Scientific notation
+    {
+        Lexer lexer("2.5e-3");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 2);
+        EXPECT_EQ(tokens[0].type, TokenType::FLOAT_LITERAL);
+        EXPECT_EQ(tokens[0].lexeme, "2.5e-3");
+    }
+    
+    // Float without fractional part
+    {
+        Lexer lexer("10.");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 2);
+        EXPECT_EQ(tokens[0].type, TokenType::FLOAT_LITERAL);
+        EXPECT_EQ(tokens[0].lexeme, "10.");
+    }
+}
+
+TEST(LexerTest, ScanHexadecimalLiterals) {
+    // Simple hex
+    {
+        Lexer lexer("0xFF");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 2);
+        EXPECT_EQ(tokens[0].type, TokenType::INTEGER_LITERAL);
+        EXPECT_EQ(tokens[0].lexeme, "0xFF");
+    }
+    
+    // Lowercase hex
+    {
+        Lexer lexer("0x1234abcd");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 2);
+        EXPECT_EQ(tokens[0].type, TokenType::INTEGER_LITERAL);
+        EXPECT_EQ(tokens[0].lexeme, "0x1234abcd");
+    }
+    
+    // Mixed case
+    {
+        Lexer lexer("0xDeAdBeEf");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 2);
+        EXPECT_EQ(tokens[0].type, TokenType::INTEGER_LITERAL);
+        EXPECT_EQ(tokens[0].lexeme, "0xDeAdBeEf");
+    }
+}
+
+TEST(LexerTest, ScanBinaryLiterals) {
+    // Simple binary
+    {
+        Lexer lexer("0b1010");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 2);
+        EXPECT_EQ(tokens[0].type, TokenType::INTEGER_LITERAL);
+        EXPECT_EQ(tokens[0].lexeme, "0b1010");
+    }
+    
+    // Longer binary
+    {
+        Lexer lexer("0b11111111");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 2);
+        EXPECT_EQ(tokens[0].type, TokenType::INTEGER_LITERAL);
+        EXPECT_EQ(tokens[0].lexeme, "0b11111111");
+    }
+}
+
+TEST(LexerTest, NumericLiteralEdgeCases) {
+    // Multiple numbers with spaces
+    {
+        Lexer lexer("42 3.14 0xFF");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 4);
+        EXPECT_EQ(tokens[0].type, TokenType::INTEGER_LITERAL);
+        EXPECT_EQ(tokens[0].lexeme, "42");
+        EXPECT_EQ(tokens[1].type, TokenType::FLOAT_LITERAL);
+        EXPECT_EQ(tokens[1].lexeme, "3.14");
+        EXPECT_EQ(tokens[2].type, TokenType::INTEGER_LITERAL);
+        EXPECT_EQ(tokens[2].lexeme, "0xFF");
+    }
+    
+    // Scientific notation variations
+    {
+        Lexer lexer("1e10");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 2);
+        EXPECT_EQ(tokens[0].type, TokenType::FLOAT_LITERAL);
+        EXPECT_EQ(tokens[0].lexeme, "1e10");
+    }
+    
+    {
+        Lexer lexer("3.14e+5");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 2);
+        EXPECT_EQ(tokens[0].type, TokenType::FLOAT_LITERAL);
+        EXPECT_EQ(tokens[0].lexeme, "3.14e+5");
+    }
+    
+    // Zero prefix cases
+    {
+        Lexer lexer("0");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 2);
+        EXPECT_EQ(tokens[0].type, TokenType::INTEGER_LITERAL);
+        EXPECT_EQ(tokens[0].lexeme, "0");
+    }
+    
+    // Float with h suffix (half precision)
+    {
+        Lexer lexer("1.5h");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 2);
+        EXPECT_EQ(tokens[0].type, TokenType::FLOAT_LITERAL);
+        EXPECT_EQ(tokens[0].lexeme, "1.5h");
+    }
+}


### PR DESCRIPTION
## Summary
- Implement comprehensive numeric literal support for the Metal Shader Language lexer
- Add support for floating-point, hexadecimal, and binary literals
- Follow TDD approach with tests written first

## Changes
- **Float literals**: Support for decimal notation (3.14), scientific notation (2.5e-3), trailing dot (10.), and f/h suffixes
- **Hexadecimal literals**: Support for 0x prefix with mixed case (0xFF, 0xDeAdBeEf)
- **Binary literals**: Support for 0b prefix (0b1010, 0b11111111)
- Refactored lexer to use helper methods for better code organization

## Test Plan
- [x] All existing tests pass
- [x] Added comprehensive tests for float literals
- [x] Added tests for hexadecimal literals
- [x] Added tests for binary literals
- [x] Added edge case tests for multiple numbers and various formats

Closes #1

🤖 Generated with [Claude Code](https://claude.ai/code)