### PR TITLE
feat: Add identifier and keyword support

### DIFF
--- a/include/msl_parser/lexer.h
+++ b/include/msl_parser/lexer.h
@@ -22,9 +22,12 @@ private:
     
     void scanToken();
     void number();
+    void identifier();
     
     bool isDigit(char c);
     bool isHexDigit(char c);
+    bool isAlpha(char c);
+    bool isAlphaNumeric(char c);
     bool isAtEnd();
     char advance();
     char peek();

--- a/include/msl_parser/token.h
+++ b/include/msl_parser/token.h
@@ -7,11 +7,68 @@
 namespace msl_parser {
 
 enum class TokenType {
+    // Literals
     INTEGER_LITERAL,
     FLOAT_LITERAL,
+    
+    // Identifier
     IDENTIFIER,
+    
+    // Keywords - Types
+    VOID,
+    BOOL,
+    INT,
+    UINT,
+    SHORT,
+    USHORT,
+    CHAR,
+    UCHAR,
+    FLOAT,
+    HALF,
+    DOUBLE,
+    
+    // Keywords - Vector Types
+    FLOAT2,
+    FLOAT3,
+    FLOAT4,
+    INT2,
+    INT3,
+    INT4,
+    UINT2,
+    UINT3,
+    UINT4,
+    
+    // Keywords - Matrix Types
+    FLOAT2X2,
+    FLOAT3X3,
+    FLOAT4X4,
+    
+    // Keywords - Control Flow
+    IF,
+    ELSE,
+    FOR,
+    WHILE,
+    DO,
+    SWITCH,
+    CASE,
+    DEFAULT,
+    BREAK,
+    CONTINUE,
+    RETURN,
+    
+    // Keywords - Metal-specific
     KERNEL,
+    VERTEX,
+    FRAGMENT,
+    DEVICE,
+    CONSTANT,
+    THREAD,
+    THREADGROUP,
+    
+    // Operators (placeholder for now)
     PLUS,
+    
+    // Special
     END_OF_FILE
 };
 

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -1,7 +1,61 @@
 #include "msl_parser/lexer.h"
 #include <cctype>
+#include <unordered_map>
 
 namespace msl_parser {
+
+static const std::unordered_map<std::string, TokenType> keywords = {
+    // Types
+    {"void", TokenType::VOID},
+    {"bool", TokenType::BOOL},
+    {"int", TokenType::INT},
+    {"uint", TokenType::UINT},
+    {"short", TokenType::SHORT},
+    {"ushort", TokenType::USHORT},
+    {"char", TokenType::CHAR},
+    {"uchar", TokenType::UCHAR},
+    {"float", TokenType::FLOAT},
+    {"half", TokenType::HALF},
+    {"double", TokenType::DOUBLE},
+    
+    // Vector Types
+    {"float2", TokenType::FLOAT2},
+    {"float3", TokenType::FLOAT3},
+    {"float4", TokenType::FLOAT4},
+    {"int2", TokenType::INT2},
+    {"int3", TokenType::INT3},
+    {"int4", TokenType::INT4},
+    {"uint2", TokenType::UINT2},
+    {"uint3", TokenType::UINT3},
+    {"uint4", TokenType::UINT4},
+    
+    // Matrix Types
+    {"float2x2", TokenType::FLOAT2X2},
+    {"float3x3", TokenType::FLOAT3X3},
+    {"float4x4", TokenType::FLOAT4X4},
+    
+    // Control Flow
+    {"if", TokenType::IF},
+    {"else", TokenType::ELSE},
+    {"for", TokenType::FOR},
+    {"while", TokenType::WHILE},
+    {"do", TokenType::DO},
+    {"switch", TokenType::SWITCH},
+    {"case", TokenType::CASE},
+    {"default", TokenType::DEFAULT},
+    {"break", TokenType::BREAK},
+    {"continue", TokenType::CONTINUE},
+    {"return", TokenType::RETURN},
+    
+    // Metal-specific
+    {"kernel", TokenType::KERNEL},
+    {"vertex", TokenType::VERTEX},
+    {"fragment", TokenType::FRAGMENT},
+    {"device", TokenType::DEVICE},
+    {"constant", TokenType::CONSTANT},
+    {"thread", TokenType::THREAD},
+    {"threadgroup", TokenType::THREADGROUP},
+};
 
 Lexer::Lexer(const std::string& source) : source(source) {}
 
@@ -20,6 +74,8 @@ void Lexer::scanToken() {
     
     if (isDigit(c)) {
         number();
+    } else if (isAlpha(c)) {
+        identifier();
     } else if (c == ' ' || c == '\r' || c == '\t') {
         // Ignore whitespace
     } else if (c == '\n') {
@@ -132,6 +188,30 @@ char Lexer::peekNext() {
 void Lexer::addToken(TokenType type) {
     std::string text = source.substr(start, current - start);
     tokens.push_back(Token(type, text, line, column - text.length()));
+}
+
+void Lexer::identifier() {
+    while (isAlphaNumeric(peek())) {
+        advance();
+    }
+    
+    std::string text = source.substr(start, current - start);
+    
+    // Check if it's a keyword
+    auto it = keywords.find(text);
+    TokenType type = (it != keywords.end()) ? it->second : TokenType::IDENTIFIER;
+    
+    addToken(type);
+}
+
+bool Lexer::isAlpha(char c) {
+    return (c >= 'a' && c <= 'z') ||
+           (c >= 'A' && c <= 'Z') ||
+           c == '_';
+}
+
+bool Lexer::isAlphaNumeric(char c) {
+    return isAlpha(c) || isDigit(c);
 }
 
 } // namespace msl_parser

--- a/src/token.cpp
+++ b/src/token.cpp
@@ -4,12 +4,70 @@ namespace msl_parser {
 
 const char* tokenTypeToString(TokenType type) {
     switch (type) {
+        // Literals
         case TokenType::INTEGER_LITERAL: return "INTEGER_LITERAL";
         case TokenType::FLOAT_LITERAL: return "FLOAT_LITERAL";
+        
+        // Identifier
         case TokenType::IDENTIFIER: return "IDENTIFIER";
+        
+        // Keywords - Types
+        case TokenType::VOID: return "VOID";
+        case TokenType::BOOL: return "BOOL";
+        case TokenType::INT: return "INT";
+        case TokenType::UINT: return "UINT";
+        case TokenType::SHORT: return "SHORT";
+        case TokenType::USHORT: return "USHORT";
+        case TokenType::CHAR: return "CHAR";
+        case TokenType::UCHAR: return "UCHAR";
+        case TokenType::FLOAT: return "FLOAT";
+        case TokenType::HALF: return "HALF";
+        case TokenType::DOUBLE: return "DOUBLE";
+        
+        // Keywords - Vector Types
+        case TokenType::FLOAT2: return "FLOAT2";
+        case TokenType::FLOAT3: return "FLOAT3";
+        case TokenType::FLOAT4: return "FLOAT4";
+        case TokenType::INT2: return "INT2";
+        case TokenType::INT3: return "INT3";
+        case TokenType::INT4: return "INT4";
+        case TokenType::UINT2: return "UINT2";
+        case TokenType::UINT3: return "UINT3";
+        case TokenType::UINT4: return "UINT4";
+        
+        // Keywords - Matrix Types
+        case TokenType::FLOAT2X2: return "FLOAT2X2";
+        case TokenType::FLOAT3X3: return "FLOAT3X3";
+        case TokenType::FLOAT4X4: return "FLOAT4X4";
+        
+        // Keywords - Control Flow
+        case TokenType::IF: return "IF";
+        case TokenType::ELSE: return "ELSE";
+        case TokenType::FOR: return "FOR";
+        case TokenType::WHILE: return "WHILE";
+        case TokenType::DO: return "DO";
+        case TokenType::SWITCH: return "SWITCH";
+        case TokenType::CASE: return "CASE";
+        case TokenType::DEFAULT: return "DEFAULT";
+        case TokenType::BREAK: return "BREAK";
+        case TokenType::CONTINUE: return "CONTINUE";
+        case TokenType::RETURN: return "RETURN";
+        
+        // Keywords - Metal-specific
         case TokenType::KERNEL: return "KERNEL";
+        case TokenType::VERTEX: return "VERTEX";
+        case TokenType::FRAGMENT: return "FRAGMENT";
+        case TokenType::DEVICE: return "DEVICE";
+        case TokenType::CONSTANT: return "CONSTANT";
+        case TokenType::THREAD: return "THREAD";
+        case TokenType::THREADGROUP: return "THREADGROUP";
+        
+        // Operators
         case TokenType::PLUS: return "PLUS";
+        
+        // Special
         case TokenType::END_OF_FILE: return "END_OF_FILE";
+        
         default: return "UNKNOWN";
     }
 }

--- a/tests/test_lexer.cpp
+++ b/tests/test_lexer.cpp
@@ -163,3 +163,205 @@ TEST(LexerTest, NumericLiteralEdgeCases) {
         EXPECT_EQ(tokens[0].lexeme, "1.5h");
     }
 }
+
+TEST(LexerTest, ScanIdentifiers) {
+    // Simple identifier
+    {
+        Lexer lexer("position");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 2);
+        EXPECT_EQ(tokens[0].type, TokenType::IDENTIFIER);
+        EXPECT_EQ(tokens[0].lexeme, "position");
+    }
+    
+    // Identifier with numbers
+    {
+        Lexer lexer("vertex1");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 2);
+        EXPECT_EQ(tokens[0].type, TokenType::IDENTIFIER);
+        EXPECT_EQ(tokens[0].lexeme, "vertex1");
+    }
+    
+    // Identifier with underscore
+    {
+        Lexer lexer("_private_var");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 2);
+        EXPECT_EQ(tokens[0].type, TokenType::IDENTIFIER);
+        EXPECT_EQ(tokens[0].lexeme, "_private_var");
+    }
+    
+    // Multiple identifiers
+    {
+        Lexer lexer("foo bar baz");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 4);
+        EXPECT_EQ(tokens[0].type, TokenType::IDENTIFIER);
+        EXPECT_EQ(tokens[0].lexeme, "foo");
+        EXPECT_EQ(tokens[1].type, TokenType::IDENTIFIER);
+        EXPECT_EQ(tokens[1].lexeme, "bar");
+        EXPECT_EQ(tokens[2].type, TokenType::IDENTIFIER);
+        EXPECT_EQ(tokens[2].lexeme, "baz");
+    }
+}
+
+TEST(LexerTest, ScanKeywords) {
+    // Basic type keywords
+    {
+        Lexer lexer("void int float bool");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 5);
+        EXPECT_EQ(tokens[0].type, TokenType::VOID);
+        EXPECT_EQ(tokens[0].lexeme, "void");
+        EXPECT_EQ(tokens[1].type, TokenType::INT);
+        EXPECT_EQ(tokens[1].lexeme, "int");
+        EXPECT_EQ(tokens[2].type, TokenType::FLOAT);
+        EXPECT_EQ(tokens[2].lexeme, "float");
+        EXPECT_EQ(tokens[3].type, TokenType::BOOL);
+        EXPECT_EQ(tokens[3].lexeme, "bool");
+    }
+    
+    // Control flow keywords
+    {
+        Lexer lexer("if else return");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 4);
+        EXPECT_EQ(tokens[0].type, TokenType::IF);
+        EXPECT_EQ(tokens[0].lexeme, "if");
+        EXPECT_EQ(tokens[1].type, TokenType::ELSE);
+        EXPECT_EQ(tokens[1].lexeme, "else");
+        EXPECT_EQ(tokens[2].type, TokenType::RETURN);
+        EXPECT_EQ(tokens[2].lexeme, "return");
+    }
+    
+    // Metal-specific keywords
+    {
+        Lexer lexer("kernel vertex fragment device constant");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 6);
+        EXPECT_EQ(tokens[0].type, TokenType::KERNEL);
+        EXPECT_EQ(tokens[0].lexeme, "kernel");
+        EXPECT_EQ(tokens[1].type, TokenType::VERTEX);
+        EXPECT_EQ(tokens[1].lexeme, "vertex");
+        EXPECT_EQ(tokens[2].type, TokenType::FRAGMENT);
+        EXPECT_EQ(tokens[2].lexeme, "fragment");
+        EXPECT_EQ(tokens[3].type, TokenType::DEVICE);
+        EXPECT_EQ(tokens[3].lexeme, "device");
+        EXPECT_EQ(tokens[4].type, TokenType::CONSTANT);
+        EXPECT_EQ(tokens[4].lexeme, "constant");
+    }
+    
+    // Keywords vs identifiers
+    {
+        Lexer lexer("int integer");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 3);
+        EXPECT_EQ(tokens[0].type, TokenType::INT);
+        EXPECT_EQ(tokens[0].lexeme, "int");
+        EXPECT_EQ(tokens[1].type, TokenType::IDENTIFIER);
+        EXPECT_EQ(tokens[1].lexeme, "integer");
+    }
+}
+
+TEST(LexerTest, IdentifierKeywordEdgeCases) {
+    // Mixed identifiers, keywords, and numbers
+    {
+        Lexer lexer("float4 position = float4(1.0);");
+        auto tokens = lexer.scanTokens();
+        
+        // Currently: float4, position, float4, 1.0, EOF (operators are skipped)
+        ASSERT_EQ(tokens.size(), 5);
+        EXPECT_EQ(tokens[0].type, TokenType::FLOAT4);  // float4 is now a keyword
+        EXPECT_EQ(tokens[0].lexeme, "float4");
+        EXPECT_EQ(tokens[1].type, TokenType::IDENTIFIER);
+        EXPECT_EQ(tokens[1].lexeme, "position");
+        // = and other operators will be skipped for now
+        EXPECT_EQ(tokens[2].type, TokenType::FLOAT4);
+        EXPECT_EQ(tokens[2].lexeme, "float4");
+        EXPECT_EQ(tokens[3].type, TokenType::FLOAT_LITERAL);
+        EXPECT_EQ(tokens[3].lexeme, "1.0");
+    }
+    
+    // Underscore variations
+    {
+        Lexer lexer("_foo foo_ _foo_ __foo__");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 5);
+        EXPECT_EQ(tokens[0].type, TokenType::IDENTIFIER);
+        EXPECT_EQ(tokens[0].lexeme, "_foo");
+        EXPECT_EQ(tokens[1].type, TokenType::IDENTIFIER);
+        EXPECT_EQ(tokens[1].lexeme, "foo_");
+        EXPECT_EQ(tokens[2].type, TokenType::IDENTIFIER);
+        EXPECT_EQ(tokens[2].lexeme, "_foo_");
+        EXPECT_EQ(tokens[3].type, TokenType::IDENTIFIER);
+        EXPECT_EQ(tokens[3].lexeme, "__foo__");
+    }
+    
+    // Case sensitivity
+    {
+        Lexer lexer("INT Int int");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 4);
+        EXPECT_EQ(tokens[0].type, TokenType::IDENTIFIER);  // INT is not same as int
+        EXPECT_EQ(tokens[0].lexeme, "INT");
+        EXPECT_EQ(tokens[1].type, TokenType::IDENTIFIER);  // Int is not same as int
+        EXPECT_EQ(tokens[1].lexeme, "Int");
+        EXPECT_EQ(tokens[2].type, TokenType::INT);         // int is keyword
+        EXPECT_EQ(tokens[2].lexeme, "int");
+    }
+}
+
+TEST(LexerTest, VectorAndMatrixTypes) {
+    // Vector types
+    {
+        Lexer lexer("float2 float3 float4 int2 int3 int4 uint2 uint3 uint4");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 10);
+        EXPECT_EQ(tokens[0].type, TokenType::FLOAT2);
+        EXPECT_EQ(tokens[1].type, TokenType::FLOAT3);
+        EXPECT_EQ(tokens[2].type, TokenType::FLOAT4);
+        EXPECT_EQ(tokens[3].type, TokenType::INT2);
+        EXPECT_EQ(tokens[4].type, TokenType::INT3);
+        EXPECT_EQ(tokens[5].type, TokenType::INT4);
+        EXPECT_EQ(tokens[6].type, TokenType::UINT2);
+        EXPECT_EQ(tokens[7].type, TokenType::UINT3);
+        EXPECT_EQ(tokens[8].type, TokenType::UINT4);
+    }
+    
+    // Matrix types
+    {
+        Lexer lexer("float2x2 float3x3 float4x4");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 4);
+        EXPECT_EQ(tokens[0].type, TokenType::FLOAT2X2);
+        EXPECT_EQ(tokens[1].type, TokenType::FLOAT3X3);
+        EXPECT_EQ(tokens[2].type, TokenType::FLOAT4X4);
+    }
+    
+    // float4 as identifier vs float and 4
+    {
+        Lexer lexer("float4 float 4");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 4);
+        EXPECT_EQ(tokens[0].type, TokenType::FLOAT4);
+        EXPECT_EQ(tokens[0].lexeme, "float4");
+        EXPECT_EQ(tokens[1].type, TokenType::FLOAT);
+        EXPECT_EQ(tokens[1].lexeme, "float");
+        EXPECT_EQ(tokens[2].type, TokenType::INTEGER_LITERAL);
+        EXPECT_EQ(tokens[2].lexeme, "4");
+    }
+}


### PR DESCRIPTION
## Summary
- Implement comprehensive identifier and keyword support for the Metal Shader Language lexer
- Add support for Metal-specific keywords and type keywords including vectors and matrices
- Follow TDD approach with tests written first

## Changes
- **Identifier scanning**: Support for identifiers with letters, numbers, and underscores
- **Keyword recognition**: Hash map-based keyword lookup for efficient detection
- **Type keywords**: Basic types (int, float, bool, etc.) and Metal-specific types
- **Vector types**: float2/3/4, int2/3/4, uint2/3/4
- **Matrix types**: float2x2, float3x3, float4x4
- **Metal keywords**: kernel, vertex, fragment, device, constant, thread, threadgroup
- **Case sensitivity**: Keywords are case-sensitive (lowercase only)

## Implementation Details
- Added `identifier()` method to scan identifiers and check against keyword map
- Added `isAlpha()` and `isAlphaNumeric()` helper methods
- Extended TokenType enum with all supported keywords
- Created static keyword map for O(1) lookup performance

## Test Plan
- [x] All existing tests pass
- [x] Added tests for simple and complex identifiers
- [x] Added tests for all keyword categories
- [x] Added edge case tests for case sensitivity and keyword vs identifier distinction
- [x] Added tests for vector and matrix type keywords

Closes #2

🤖 Generated with [Claude Code](https://claude.ai/code)