### PR TITLE
feat: Add delimiter and punctuation support to lexer (#4)

### DIFF
--- a/include/msl_parser/token.h
+++ b/include/msl_parser/token.h
@@ -107,6 +107,25 @@ enum class TokenType {
     QUESTION,
     COLON,
     
+    // Delimiters
+    LEFT_PAREN,
+    RIGHT_PAREN,
+    LEFT_BRACE,
+    RIGHT_BRACE,
+    LEFT_BRACKET,
+    RIGHT_BRACKET,
+    
+    // Punctuation
+    SEMICOLON,
+    COMMA,
+    DOT,
+    ARROW,
+    SCOPE_RESOLUTION,
+    
+    // Attributes
+    ATTRIBUTE_LEFT,
+    ATTRIBUTE_RIGHT,
+    
     // Special
     END_OF_FILE
 };

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -103,6 +103,9 @@ void Lexer::scanToken() {
                 } else if (peek() == '=') {
                     advance();
                     addToken(TokenType::MINUS_ASSIGN);
+                } else if (peek() == '>') {
+                    advance();
+                    addToken(TokenType::ARROW);
                 } else {
                     addToken(TokenType::MINUS);
                 }
@@ -195,7 +198,49 @@ void Lexer::scanToken() {
                 addToken(TokenType::QUESTION);
                 break;
             case ':':
-                addToken(TokenType::COLON);
+                if (peek() == ':') {
+                    advance();
+                    addToken(TokenType::SCOPE_RESOLUTION);
+                } else {
+                    addToken(TokenType::COLON);
+                }
+                break;
+            case '(':
+                addToken(TokenType::LEFT_PAREN);
+                break;
+            case ')':
+                addToken(TokenType::RIGHT_PAREN);
+                break;
+            case '{':
+                addToken(TokenType::LEFT_BRACE);
+                break;
+            case '}':
+                addToken(TokenType::RIGHT_BRACE);
+                break;
+            case '[':
+                if (peek() == '[') {
+                    advance();
+                    addToken(TokenType::ATTRIBUTE_LEFT);
+                } else {
+                    addToken(TokenType::LEFT_BRACKET);
+                }
+                break;
+            case ']':
+                if (peek() == ']') {
+                    advance();
+                    addToken(TokenType::ATTRIBUTE_RIGHT);
+                } else {
+                    addToken(TokenType::RIGHT_BRACKET);
+                }
+                break;
+            case ';':
+                addToken(TokenType::SEMICOLON);
+                break;
+            case ',':
+                addToken(TokenType::COMMA);
+                break;
+            case '.':
+                addToken(TokenType::DOT);
                 break;
             default:
                 // Skip unknown characters for now

--- a/src/token.cpp
+++ b/src/token.cpp
@@ -104,6 +104,25 @@ const char* tokenTypeToString(TokenType type) {
         case TokenType::QUESTION: return "QUESTION";
         case TokenType::COLON: return "COLON";
         
+        // Delimiters
+        case TokenType::LEFT_PAREN: return "LEFT_PAREN";
+        case TokenType::RIGHT_PAREN: return "RIGHT_PAREN";
+        case TokenType::LEFT_BRACE: return "LEFT_BRACE";
+        case TokenType::RIGHT_BRACE: return "RIGHT_BRACE";
+        case TokenType::LEFT_BRACKET: return "LEFT_BRACKET";
+        case TokenType::RIGHT_BRACKET: return "RIGHT_BRACKET";
+        
+        // Punctuation
+        case TokenType::SEMICOLON: return "SEMICOLON";
+        case TokenType::COMMA: return "COMMA";
+        case TokenType::DOT: return "DOT";
+        case TokenType::ARROW: return "ARROW";
+        case TokenType::SCOPE_RESOLUTION: return "SCOPE_RESOLUTION";
+        
+        // Attributes
+        case TokenType::ATTRIBUTE_LEFT: return "ATTRIBUTE_LEFT";
+        case TokenType::ATTRIBUTE_RIGHT: return "ATTRIBUTE_RIGHT";
+        
         // Special
         case TokenType::END_OF_FILE: return "END_OF_FILE";
         

--- a/tests/test_lexer.cpp
+++ b/tests/test_lexer.cpp
@@ -278,8 +278,8 @@ TEST(LexerTest, IdentifierKeywordEdgeCases) {
         Lexer lexer("float4 position = float4(1.0);");
         auto tokens = lexer.scanTokens();
         
-        // Now includes = operator
-        ASSERT_EQ(tokens.size(), 6);
+        // Now includes = operator, parentheses, dot, and semicolon
+        ASSERT_EQ(tokens.size(), 9);
         EXPECT_EQ(tokens[0].type, TokenType::FLOAT4);  // float4 is now a keyword
         EXPECT_EQ(tokens[0].lexeme, "float4");
         EXPECT_EQ(tokens[1].type, TokenType::IDENTIFIER);
@@ -288,8 +288,15 @@ TEST(LexerTest, IdentifierKeywordEdgeCases) {
         EXPECT_EQ(tokens[2].lexeme, "=");
         EXPECT_EQ(tokens[3].type, TokenType::FLOAT4);
         EXPECT_EQ(tokens[3].lexeme, "float4");
-        EXPECT_EQ(tokens[4].type, TokenType::FLOAT_LITERAL);
-        EXPECT_EQ(tokens[4].lexeme, "1.0");
+        EXPECT_EQ(tokens[4].type, TokenType::LEFT_PAREN);
+        EXPECT_EQ(tokens[4].lexeme, "(");
+        EXPECT_EQ(tokens[5].type, TokenType::FLOAT_LITERAL);
+        EXPECT_EQ(tokens[5].lexeme, "1.0");
+        EXPECT_EQ(tokens[6].type, TokenType::RIGHT_PAREN);
+        EXPECT_EQ(tokens[6].lexeme, ")");
+        EXPECT_EQ(tokens[7].type, TokenType::SEMICOLON);
+        EXPECT_EQ(tokens[7].lexeme, ";");
+        EXPECT_EQ(tokens[8].type, TokenType::END_OF_FILE);
     }
     
     // Underscore variations
@@ -593,5 +600,177 @@ TEST(LexerTest, OperatorEdgeCases) {
         EXPECT_EQ(tokens[3].type, TokenType::IDENTIFIER);
         EXPECT_EQ(tokens[4].type, TokenType::MINUS_MINUS);
         EXPECT_EQ(tokens[5].type, TokenType::END_OF_FILE);
+    }
+}
+
+TEST(LexerTest, ParenthesesBracesBrackets) {
+    // Parentheses
+    {
+        Lexer lexer("()");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 3);
+        EXPECT_EQ(tokens[0].type, TokenType::LEFT_PAREN);
+        EXPECT_EQ(tokens[0].lexeme, "(");
+        EXPECT_EQ(tokens[1].type, TokenType::RIGHT_PAREN);
+        EXPECT_EQ(tokens[1].lexeme, ")");
+        EXPECT_EQ(tokens[2].type, TokenType::END_OF_FILE);
+    }
+    
+    // Braces
+    {
+        Lexer lexer("{}");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 3);
+        EXPECT_EQ(tokens[0].type, TokenType::LEFT_BRACE);
+        EXPECT_EQ(tokens[0].lexeme, "{");
+        EXPECT_EQ(tokens[1].type, TokenType::RIGHT_BRACE);
+        EXPECT_EQ(tokens[1].lexeme, "}");
+        EXPECT_EQ(tokens[2].type, TokenType::END_OF_FILE);
+    }
+    
+    // Brackets
+    {
+        Lexer lexer("[]");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 3);
+        EXPECT_EQ(tokens[0].type, TokenType::LEFT_BRACKET);
+        EXPECT_EQ(tokens[0].lexeme, "[");
+        EXPECT_EQ(tokens[1].type, TokenType::RIGHT_BRACKET);
+        EXPECT_EQ(tokens[1].lexeme, "]");
+        EXPECT_EQ(tokens[2].type, TokenType::END_OF_FILE);
+    }
+    
+    // Mixed delimiters
+    {
+        Lexer lexer("(){}[]");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 7);
+        EXPECT_EQ(tokens[0].type, TokenType::LEFT_PAREN);
+        EXPECT_EQ(tokens[1].type, TokenType::RIGHT_PAREN);
+        EXPECT_EQ(tokens[2].type, TokenType::LEFT_BRACE);
+        EXPECT_EQ(tokens[3].type, TokenType::RIGHT_BRACE);
+        EXPECT_EQ(tokens[4].type, TokenType::LEFT_BRACKET);
+        EXPECT_EQ(tokens[5].type, TokenType::RIGHT_BRACKET);
+        EXPECT_EQ(tokens[6].type, TokenType::END_OF_FILE);
+    }
+}
+
+TEST(LexerTest, Punctuation) {
+    // Basic punctuation
+    {
+        Lexer lexer("; , .");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 4);
+        EXPECT_EQ(tokens[0].type, TokenType::SEMICOLON);
+        EXPECT_EQ(tokens[0].lexeme, ";");
+        EXPECT_EQ(tokens[1].type, TokenType::COMMA);
+        EXPECT_EQ(tokens[1].lexeme, ",");
+        EXPECT_EQ(tokens[2].type, TokenType::DOT);
+        EXPECT_EQ(tokens[2].lexeme, ".");
+        EXPECT_EQ(tokens[3].type, TokenType::END_OF_FILE);
+    }
+    
+    // In context
+    {
+        Lexer lexer("foo.bar;");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 5);
+        EXPECT_EQ(tokens[0].type, TokenType::IDENTIFIER);
+        EXPECT_EQ(tokens[1].type, TokenType::DOT);
+        EXPECT_EQ(tokens[2].type, TokenType::IDENTIFIER);
+        EXPECT_EQ(tokens[3].type, TokenType::SEMICOLON);
+        EXPECT_EQ(tokens[4].type, TokenType::END_OF_FILE);
+    }
+    
+    // Function call with arguments
+    {
+        Lexer lexer("func(a, b, c);");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 10);
+        EXPECT_EQ(tokens[0].type, TokenType::IDENTIFIER);
+        EXPECT_EQ(tokens[1].type, TokenType::LEFT_PAREN);
+        EXPECT_EQ(tokens[2].type, TokenType::IDENTIFIER);
+        EXPECT_EQ(tokens[3].type, TokenType::COMMA);
+        EXPECT_EQ(tokens[4].type, TokenType::IDENTIFIER);
+        EXPECT_EQ(tokens[5].type, TokenType::COMMA);
+        EXPECT_EQ(tokens[6].type, TokenType::IDENTIFIER);
+        EXPECT_EQ(tokens[7].type, TokenType::RIGHT_PAREN);
+        EXPECT_EQ(tokens[8].type, TokenType::SEMICOLON);
+        EXPECT_EQ(tokens[9].type, TokenType::END_OF_FILE);
+    }
+}
+
+TEST(LexerTest, MultiCharacterDelimiters) {
+    // Arrow operator
+    {
+        Lexer lexer("->");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 2);
+        EXPECT_EQ(tokens[0].type, TokenType::ARROW);
+        EXPECT_EQ(tokens[0].lexeme, "->");
+        EXPECT_EQ(tokens[1].type, TokenType::END_OF_FILE);
+    }
+    
+    // Scope resolution
+    {
+        Lexer lexer("::");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 2);
+        EXPECT_EQ(tokens[0].type, TokenType::SCOPE_RESOLUTION);
+        EXPECT_EQ(tokens[0].lexeme, "::");
+        EXPECT_EQ(tokens[1].type, TokenType::END_OF_FILE);
+    }
+    
+    // Attribute brackets
+    {
+        Lexer lexer("[[ ]]");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 3);
+        EXPECT_EQ(tokens[0].type, TokenType::ATTRIBUTE_LEFT);
+        EXPECT_EQ(tokens[0].lexeme, "[[");
+        EXPECT_EQ(tokens[1].type, TokenType::ATTRIBUTE_RIGHT);
+        EXPECT_EQ(tokens[1].lexeme, "]]");
+        EXPECT_EQ(tokens[2].type, TokenType::END_OF_FILE);
+    }
+    
+    // In context
+    {
+        Lexer lexer("foo::bar->baz");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 6);
+        EXPECT_EQ(tokens[0].type, TokenType::IDENTIFIER);
+        EXPECT_EQ(tokens[1].type, TokenType::SCOPE_RESOLUTION);
+        EXPECT_EQ(tokens[2].type, TokenType::IDENTIFIER);
+        EXPECT_EQ(tokens[3].type, TokenType::ARROW);
+        EXPECT_EQ(tokens[4].type, TokenType::IDENTIFIER);
+        EXPECT_EQ(tokens[5].type, TokenType::END_OF_FILE);
+    }
+    
+    // Attributes with content
+    {
+        Lexer lexer("[[nodiscard]] int func();");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 9);
+        EXPECT_EQ(tokens[0].type, TokenType::ATTRIBUTE_LEFT);
+        EXPECT_EQ(tokens[1].type, TokenType::IDENTIFIER);
+        EXPECT_EQ(tokens[2].type, TokenType::ATTRIBUTE_RIGHT);
+        EXPECT_EQ(tokens[3].type, TokenType::INT);
+        EXPECT_EQ(tokens[4].type, TokenType::IDENTIFIER);
+        EXPECT_EQ(tokens[5].type, TokenType::LEFT_PAREN);
+        EXPECT_EQ(tokens[6].type, TokenType::RIGHT_PAREN);
+        EXPECT_EQ(tokens[7].type, TokenType::SEMICOLON);
+        EXPECT_EQ(tokens[8].type, TokenType::END_OF_FILE);
     }
 }


### PR DESCRIPTION
## Summary
- Implemented comprehensive delimiter and punctuation support in the lexer following TDD methodology
- Added token types and scanning logic for all delimiter categories
- All tests passing with 100% coverage for delimiter tokenization

## Changes
- Added delimiter and punctuation token types in `token.h`:
  - Parentheses: `(`, `)`
  - Braces: `{`, `}`
  - Brackets: `[`, `]`
  - Punctuation: `;`, `,`, `.`
  - Multi-character delimiters: `::`, `->`, `[[`, `]]`

- Implemented delimiter scanning in `lexer.cpp`:
  - Single-character delimiter support
  - Multi-character delimiter support using peek() for `::`, `->`, `[[`, `]]`
  - Proper precedence handling for `[` vs `[[` and `]` vs `]]`

- Added comprehensive tests in `test_lexer.cpp`:
  - Test cases for all delimiter types
  - Tests for mixed delimiters
  - Tests for delimiters in context (function calls, member access)
  - Edge case tests for multi-character delimiters

## Test plan
- [x] All unit tests passing
- [x] Tested single-character delimiters
- [x] Tested multi-character delimiters
- [x] Tested delimiters in realistic code contexts
- [x] Fixed existing test that was affected by new delimiter support

Closes #4

🤖 Generated with [Claude Code](https://claude.ai/code)