### PR TITLE
feat: Add string literal support to lexer (#5)

### DIFF
--- a/include/msl_parser/lexer.h
+++ b/include/msl_parser/lexer.h
@@ -23,6 +23,7 @@ private:
     void scanToken();
     void number();
     void identifier();
+    void string();
     
     bool isDigit(char c);
     bool isHexDigit(char c);

--- a/include/msl_parser/token.h
+++ b/include/msl_parser/token.h
@@ -10,6 +10,7 @@ enum class TokenType {
     // Literals
     INTEGER_LITERAL,
     FLOAT_LITERAL,
+    STRING_LITERAL,
     
     // Identifier
     IDENTIFIER,

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -242,6 +242,9 @@ void Lexer::scanToken() {
             case '.':
                 addToken(TokenType::DOT);
                 break;
+            case '"':
+                string();
+                break;
             default:
                 // Skip unknown characters for now
                 break;
@@ -375,6 +378,36 @@ bool Lexer::isAlpha(char c) {
 
 bool Lexer::isAlphaNumeric(char c) {
     return isAlpha(c) || isDigit(c);
+}
+
+void Lexer::string() {
+    // Keep scanning until we find the closing quote
+    while (peek() != '"' && !isAtEnd()) {
+        if (peek() == '\n') {
+            line++;
+            column = 1;
+        }
+        
+        // Handle escape sequences
+        if (peek() == '\\') {
+            advance(); // consume the backslash
+            if (!isAtEnd()) {
+                advance(); // consume the escaped character
+            }
+        } else {
+            advance();
+        }
+    }
+    
+    if (isAtEnd()) {
+        // TODO: Error - Unterminated string
+        return;
+    }
+    
+    // Consume the closing "
+    advance();
+    
+    addToken(TokenType::STRING_LITERAL);
 }
 
 } // namespace msl_parser

--- a/src/token.cpp
+++ b/src/token.cpp
@@ -7,6 +7,7 @@ const char* tokenTypeToString(TokenType type) {
         // Literals
         case TokenType::INTEGER_LITERAL: return "INTEGER_LITERAL";
         case TokenType::FLOAT_LITERAL: return "FLOAT_LITERAL";
+        case TokenType::STRING_LITERAL: return "STRING_LITERAL";
         
         // Identifier
         case TokenType::IDENTIFIER: return "IDENTIFIER";

--- a/tests/test_lexer.cpp
+++ b/tests/test_lexer.cpp
@@ -774,3 +774,142 @@ TEST(LexerTest, MultiCharacterDelimiters) {
         EXPECT_EQ(tokens[8].type, TokenType::END_OF_FILE);
     }
 }
+
+TEST(LexerTest, BasicStringLiterals) {
+    // Simple string
+    {
+        Lexer lexer("\"hello world\"");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 2);
+        EXPECT_EQ(tokens[0].type, TokenType::STRING_LITERAL);
+        EXPECT_EQ(tokens[0].lexeme, "\"hello world\"");
+        EXPECT_EQ(tokens[1].type, TokenType::END_OF_FILE);
+    }
+    
+    // Empty string
+    {
+        Lexer lexer("\"\"");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 2);
+        EXPECT_EQ(tokens[0].type, TokenType::STRING_LITERAL);
+        EXPECT_EQ(tokens[0].lexeme, "\"\"");
+        EXPECT_EQ(tokens[1].type, TokenType::END_OF_FILE);
+    }
+    
+    // Multiple strings
+    {
+        Lexer lexer("\"hello\" \"world\"");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 3);
+        EXPECT_EQ(tokens[0].type, TokenType::STRING_LITERAL);
+        EXPECT_EQ(tokens[0].lexeme, "\"hello\"");
+        EXPECT_EQ(tokens[1].type, TokenType::STRING_LITERAL);
+        EXPECT_EQ(tokens[1].lexeme, "\"world\"");
+        EXPECT_EQ(tokens[2].type, TokenType::END_OF_FILE);
+    }
+    
+    // String with spaces and punctuation
+    {
+        Lexer lexer("\"Hello, World! How are you?\"");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 2);
+        EXPECT_EQ(tokens[0].type, TokenType::STRING_LITERAL);
+        EXPECT_EQ(tokens[0].lexeme, "\"Hello, World! How are you?\"");
+        EXPECT_EQ(tokens[1].type, TokenType::END_OF_FILE);
+    }
+}
+
+TEST(LexerTest, StringEscapeSequences) {
+    // Newline escape
+    {
+        Lexer lexer("\"Hello\\nWorld\"");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 2);
+        EXPECT_EQ(tokens[0].type, TokenType::STRING_LITERAL);
+        EXPECT_EQ(tokens[0].lexeme, "\"Hello\\nWorld\"");
+        EXPECT_EQ(tokens[1].type, TokenType::END_OF_FILE);
+    }
+    
+    // Tab escape
+    {
+        Lexer lexer("\"Hello\\tWorld\"");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 2);
+        EXPECT_EQ(tokens[0].type, TokenType::STRING_LITERAL);
+        EXPECT_EQ(tokens[0].lexeme, "\"Hello\\tWorld\"");
+        EXPECT_EQ(tokens[1].type, TokenType::END_OF_FILE);
+    }
+    
+    // Escaped quote
+    {
+        Lexer lexer("\"Say \\\"Hello\\\" to the world\"");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 2);
+        EXPECT_EQ(tokens[0].type, TokenType::STRING_LITERAL);
+        EXPECT_EQ(tokens[0].lexeme, "\"Say \\\"Hello\\\" to the world\"");
+        EXPECT_EQ(tokens[1].type, TokenType::END_OF_FILE);
+    }
+    
+    // Escaped backslash
+    {
+        Lexer lexer("\"Path: C:\\\\Program Files\\\\\"");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 2);
+        EXPECT_EQ(tokens[0].type, TokenType::STRING_LITERAL);
+        EXPECT_EQ(tokens[0].lexeme, "\"Path: C:\\\\Program Files\\\\\"");
+        EXPECT_EQ(tokens[1].type, TokenType::END_OF_FILE);
+    }
+    
+    // Multiple escape sequences
+    {
+        Lexer lexer("\"Line 1\\nLine 2\\tTabbed\\\\Backslash\\\"Quote\"");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 2);
+        EXPECT_EQ(tokens[0].type, TokenType::STRING_LITERAL);
+        EXPECT_EQ(tokens[0].lexeme, "\"Line 1\\nLine 2\\tTabbed\\\\Backslash\\\"Quote\"");
+        EXPECT_EQ(tokens[1].type, TokenType::END_OF_FILE);
+    }
+}
+
+TEST(LexerTest, StringInContext) {
+    // String assignment
+    {
+        Lexer lexer("string message = \"Hello, World!\";");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 6);
+        EXPECT_EQ(tokens[0].type, TokenType::IDENTIFIER);  // string
+        EXPECT_EQ(tokens[1].type, TokenType::IDENTIFIER);  // message
+        EXPECT_EQ(tokens[2].type, TokenType::ASSIGN);
+        EXPECT_EQ(tokens[3].type, TokenType::STRING_LITERAL);
+        EXPECT_EQ(tokens[3].lexeme, "\"Hello, World!\"");
+        EXPECT_EQ(tokens[4].type, TokenType::SEMICOLON);
+        EXPECT_EQ(tokens[5].type, TokenType::END_OF_FILE);
+    }
+    
+    // Function call with string
+    {
+        Lexer lexer("print(\"Error: \" + msg);");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 8);
+        EXPECT_EQ(tokens[0].type, TokenType::IDENTIFIER);  // print
+        EXPECT_EQ(tokens[1].type, TokenType::LEFT_PAREN);
+        EXPECT_EQ(tokens[2].type, TokenType::STRING_LITERAL);
+        EXPECT_EQ(tokens[2].lexeme, "\"Error: \"");
+        EXPECT_EQ(tokens[3].type, TokenType::PLUS);
+        EXPECT_EQ(tokens[4].type, TokenType::IDENTIFIER);  // msg
+        EXPECT_EQ(tokens[5].type, TokenType::RIGHT_PAREN);
+        EXPECT_EQ(tokens[6].type, TokenType::SEMICOLON);
+        EXPECT_EQ(tokens[7].type, TokenType::END_OF_FILE);
+    }
+}


### PR DESCRIPTION
## Summary
- Implemented string literal support in the lexer following TDD methodology
- Added proper escape sequence handling for common escape characters
- All tests passing with comprehensive coverage for string tokenization

## Changes
- Added STRING_LITERAL token type in `token.h`

- Implemented string scanning in `lexer.cpp`:
  - Basic string literal scanning with double quotes
  - Escape sequence support for `\n`, `\t`, `\\`, `\"`, etc.
  - Proper handling of escaped characters within strings
  - Line tracking for multi-line strings

- Added comprehensive tests in `test_lexer.cpp`:
  - Basic string literal tests (simple, empty, multiple strings)
  - Escape sequence tests (newline, tab, quote, backslash)
  - String literals in context (assignments, function calls)
  - Tests for complex strings with multiple escape sequences

## Test plan
- [x] All unit tests passing
- [x] Tested basic string literals
- [x] Tested escape sequences
- [x] Tested strings in realistic code contexts
- [x] Verified all existing tests still pass

## Notes
- Error handling for unterminated strings is marked as TODO and will be addressed in a future issue
- Unicode escape sequences can be added if needed by Metal

Closes #5

🤖 Generated with [Claude Code](https://claude.ai/code)