### PR TITLE
feat: Add comment support to lexer (#6)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -4,7 +4,8 @@
       "Bash(git pull:*)",
       "Bash(git checkout:*)",
       "Bash(cmake:*)",
-      "Bash(ctest:*)"
+      "Bash(ctest:*)",
+      "Bash(gh issue:*)"
     ],
     "deny": []
   }

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -122,6 +122,26 @@ void Lexer::scanToken() {
                 if (peek() == '=') {
                     advance();
                     addToken(TokenType::DIVIDE_ASSIGN);
+                } else if (peek() == '/') {
+                    // Single-line comment
+                    while (peek() != '\n' && !isAtEnd()) {
+                        advance();
+                    }
+                } else if (peek() == '*') {
+                    // Multi-line comment
+                    advance(); // consume *
+                    while (!isAtEnd()) {
+                        if (peek() == '*' && peekNext() == '/') {
+                            advance(); // consume *
+                            advance(); // consume /
+                            break;
+                        }
+                        if (peek() == '\n') {
+                            line++;
+                            column = 1;
+                        }
+                        advance();
+                    }
                 } else {
                     addToken(TokenType::DIVIDE);
                 }

--- a/tests/test_lexer.cpp
+++ b/tests/test_lexer.cpp
@@ -913,3 +913,152 @@ TEST(LexerTest, StringInContext) {
         EXPECT_EQ(tokens[7].type, TokenType::END_OF_FILE);
     }
 }
+
+TEST(LexerTest, SingleLineComments) {
+    // Comment at the beginning
+    {
+        Lexer lexer("// This is a comment\nint x = 5;");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 6);
+        EXPECT_EQ(tokens[0].type, TokenType::INT);
+        EXPECT_EQ(tokens[1].type, TokenType::IDENTIFIER);
+        EXPECT_EQ(tokens[2].type, TokenType::ASSIGN);
+        EXPECT_EQ(tokens[3].type, TokenType::INTEGER_LITERAL);
+        EXPECT_EQ(tokens[4].type, TokenType::SEMICOLON);
+        EXPECT_EQ(tokens[5].type, TokenType::END_OF_FILE);
+    }
+    
+    // Comment at the end of line
+    {
+        Lexer lexer("int x = 5; // Initialize x");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 6);
+        EXPECT_EQ(tokens[0].type, TokenType::INT);
+        EXPECT_EQ(tokens[1].type, TokenType::IDENTIFIER);
+        EXPECT_EQ(tokens[2].type, TokenType::ASSIGN);
+        EXPECT_EQ(tokens[3].type, TokenType::INTEGER_LITERAL);
+        EXPECT_EQ(tokens[4].type, TokenType::SEMICOLON);
+        EXPECT_EQ(tokens[5].type, TokenType::END_OF_FILE);
+    }
+    
+    // Multiple comments
+    {
+        Lexer lexer("// First comment\nint x; // Second comment\n// Third comment");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 4);
+        EXPECT_EQ(tokens[0].type, TokenType::INT);
+        EXPECT_EQ(tokens[1].type, TokenType::IDENTIFIER);
+        EXPECT_EQ(tokens[2].type, TokenType::SEMICOLON);
+        EXPECT_EQ(tokens[3].type, TokenType::END_OF_FILE);
+    }
+    
+    // Empty comment
+    {
+        Lexer lexer("//\nint x;");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 4);
+        EXPECT_EQ(tokens[0].type, TokenType::INT);
+        EXPECT_EQ(tokens[1].type, TokenType::IDENTIFIER);
+        EXPECT_EQ(tokens[2].type, TokenType::SEMICOLON);
+        EXPECT_EQ(tokens[3].type, TokenType::END_OF_FILE);
+    }
+}
+
+TEST(LexerTest, MultiLineComments) {
+    // Simple multi-line comment
+    {
+        Lexer lexer("/* This is a comment */ int x;");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 4);
+        EXPECT_EQ(tokens[0].type, TokenType::INT);
+        EXPECT_EQ(tokens[1].type, TokenType::IDENTIFIER);
+        EXPECT_EQ(tokens[2].type, TokenType::SEMICOLON);
+        EXPECT_EQ(tokens[3].type, TokenType::END_OF_FILE);
+    }
+    
+    // Multi-line comment spanning lines
+    {
+        Lexer lexer("/* This is\n   a multi-line\n   comment */\nint x;");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 4);
+        EXPECT_EQ(tokens[0].type, TokenType::INT);
+        EXPECT_EQ(tokens[1].type, TokenType::IDENTIFIER);
+        EXPECT_EQ(tokens[2].type, TokenType::SEMICOLON);
+        EXPECT_EQ(tokens[3].type, TokenType::END_OF_FILE);
+    }
+    
+    // Comment in the middle of code
+    {
+        Lexer lexer("int /* type */ x /* variable */ = /* assignment */ 5;");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 6);
+        EXPECT_EQ(tokens[0].type, TokenType::INT);
+        EXPECT_EQ(tokens[1].type, TokenType::IDENTIFIER);
+        EXPECT_EQ(tokens[2].type, TokenType::ASSIGN);
+        EXPECT_EQ(tokens[3].type, TokenType::INTEGER_LITERAL);
+        EXPECT_EQ(tokens[4].type, TokenType::SEMICOLON);
+        EXPECT_EQ(tokens[5].type, TokenType::END_OF_FILE);
+    }
+    
+    // Star in comment
+    {
+        Lexer lexer("/* Comment with * star */ int x;");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 4);
+        EXPECT_EQ(tokens[0].type, TokenType::INT);
+        EXPECT_EQ(tokens[1].type, TokenType::IDENTIFIER);
+        EXPECT_EQ(tokens[2].type, TokenType::SEMICOLON);
+        EXPECT_EQ(tokens[3].type, TokenType::END_OF_FILE);
+    }
+}
+
+TEST(LexerTest, CommentsEdgeCases) {
+    // Mixed single and multi-line comments
+    {
+        Lexer lexer("// Single line\n/* Multi\nline */ int x; // End comment");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 4);
+        EXPECT_EQ(tokens[0].type, TokenType::INT);
+        EXPECT_EQ(tokens[1].type, TokenType::IDENTIFIER);
+        EXPECT_EQ(tokens[2].type, TokenType::SEMICOLON);
+        EXPECT_EQ(tokens[3].type, TokenType::END_OF_FILE);
+    }
+    
+    // Comment-like content in string
+    {
+        Lexer lexer("\"// Not a comment\" /* Real comment */ \"/* Also not */\"");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 3);
+        EXPECT_EQ(tokens[0].type, TokenType::STRING_LITERAL);
+        EXPECT_EQ(tokens[0].lexeme, "\"// Not a comment\"");
+        EXPECT_EQ(tokens[1].type, TokenType::STRING_LITERAL);
+        EXPECT_EQ(tokens[1].lexeme, "\"/* Also not */\"");
+        EXPECT_EQ(tokens[2].type, TokenType::END_OF_FILE);
+    }
+    
+    // Division operator vs comment
+    {
+        Lexer lexer("int x = 10 / 2; // Division, not comment start");
+        auto tokens = lexer.scanTokens();
+        
+        ASSERT_EQ(tokens.size(), 8);
+        EXPECT_EQ(tokens[0].type, TokenType::INT);
+        EXPECT_EQ(tokens[1].type, TokenType::IDENTIFIER);
+        EXPECT_EQ(tokens[2].type, TokenType::ASSIGN);
+        EXPECT_EQ(tokens[3].type, TokenType::INTEGER_LITERAL);
+        EXPECT_EQ(tokens[4].type, TokenType::DIVIDE);
+        EXPECT_EQ(tokens[5].type, TokenType::INTEGER_LITERAL);
+        EXPECT_EQ(tokens[6].type, TokenType::SEMICOLON);
+        EXPECT_EQ(tokens[7].type, TokenType::END_OF_FILE);
+    }
+}


### PR DESCRIPTION
## Summary
- Implemented single-line and multi-line comment support in the lexer following TDD methodology
- Comments are properly skipped during tokenization
- All tests passing with comprehensive coverage for comment handling

## Changes
- Modified `/` operator handling in `lexer.cpp`:
  - Single-line comments (`//`): Skip until end of line
  - Multi-line comments (`/* */`): Skip until closing delimiter
  - Proper precedence handling: `/=` checked before comments
  - Line tracking maintained across multi-line comments

- Added comprehensive tests in `test_lexer.cpp`:
  - Single-line comment tests (beginning, end of line, empty)
  - Multi-line comment tests (simple, spanning lines, mid-code)
  - Edge cases (mixed comments, comments in strings, division operator)
  - Verified comments don't interfere with tokenization

## Test plan
- [x] All unit tests passing
- [x] Tested single-line comments in various positions
- [x] Tested multi-line comments with proper line tracking
- [x] Tested edge cases (division vs comment, comments in strings)
- [x] Verified all existing tests still pass

## Notes
- Comments are completely skipped and don't produce tokens
- Line/column tracking remains accurate across comments
- Nested comments are not supported (standard C++ behavior)

Closes #6

🤖 Generated with [Claude Code](https://claude.ai/code)